### PR TITLE
Fix documentation 404 and formalize staging removal

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,60 @@
+name: Deploy Documentation
+
+on:
+  push:
+    paths:
+      - 'ai_docs/**'
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ai_docs/package-lock.json
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        working-directory: ai_docs
+        run: npm ci
+
+      - name: Build with VitePress
+        working-directory: ai_docs
+        run: npm run docs:build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ai_docs/docs/.vitepress/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/helplinev1-ci.yml
+++ b/.github/workflows/helplinev1-ci.yml
@@ -1,3 +1,9 @@
+# NOTE: The deploy-staging job was removed after run #21183947300 (2026-01-20)
+# failed due to SSH connectivity issues with the staging server. Staging
+# deployment is now handled outside of this pipeline. If staging CI/CD is
+# restored, add a new job here with valid SSH secrets and server configuration.
+# The orphaned "staging" environment on GitHub can be deleted via repo Settings
+# > Environments.
 name: HelplineV1 CI/CD Pipeline
 permissions:
   contents: write

--- a/ai_docs/docs/.vitepress/config.mjs
+++ b/ai_docs/docs/.vitepress/config.mjs
@@ -4,7 +4,7 @@ import { defineConfig } from 'vitepress'
 const isProd = process.env.NODE_ENV === 'production'
 
 export default defineConfig({
-    base: '/',  // Use root path to avoid CSS loading issues
+    base: '/openchsai/',
     title: "OPENCHSAI",
     description: "A Child Helpline System",
     ignoreDeadLinks: true,


### PR DESCRIPTION
## Summary
- **Add GitHub Pages deployment workflow** (`deploy-docs.yml`) — builds VitePress docs from `ai_docs/` and deploys to GitHub Pages on pushes to `main`
- **Fix VitePress base path** — changed from `'/'` to `'/openchsai/'` so CSS/JS/assets resolve correctly on the project site
- **Document staging removal** — added header comment to `helplinev1-ci.yml` explaining why `deploy-staging` was removed (SSH failure in run #21183947300) and noting the orphaned `staging` environment can be deleted

## Context
The documentation URL http://bitz-it-consulting-ltd.github.io/openchsai/ returns HTTP 404 because:
1. GitHub Pages was configured with `build_type: "workflow"` but no deployment workflow existed
2. The VitePress `base` was set to `'/'` instead of `'/openchsai/'`

The staging deployment failure (run #21183947300, 2026-01-20) was a separate SSH connectivity issue. The `deploy-staging` job was already removed from the workflow but this was undocumented.

## Post-merge action
- Delete the orphaned **staging** environment via repo Settings > Environments
- Verify docs deploy at https://bitz-it-consulting-ltd.github.io/openchsai/

## Test plan
- [ ] Merge to `main` triggers the `Deploy Documentation` workflow
- [ ] VitePress build succeeds (no missing deps or broken imports)
- [ ] Documentation site loads at https://bitz-it-consulting-ltd.github.io/openchsai/
- [ ] CSS and assets load correctly (base path `/openchsai/` applied)
- [ ] Existing HelplineV1 CI/CD pipeline unaffected (comment-only change)