### PR TITLE
feat: AI insights panel displays post-call insights for the agent's last call

### DIFF
--- a/Helplinev2/finalui/src/components/case-create/CaseCreate.vue
+++ b/Helplinev2/finalui/src/components/case-create/CaseCreate.vue
@@ -150,6 +150,7 @@
   import { useClientStore } from '@/stores/clients';
   import { usePerpetratorStore } from '@/stores/perpetrators';
   import { useActiveCallStore } from '@/stores/activeCall';
+  import { useAiInsightsFetcher } from '@/composables/useAiInsightsFetcher';
 
   import CaseHeader from '@/components/case-create/CaseHeader.vue';
   import ProgressTracker from '@/components/case-create/ProgressTracker.vue';
@@ -193,6 +194,7 @@
       };
 
       const activeCallStore = useActiveCallStore();
+      const { fetchAiInsightsForCall } = useAiInsightsFetcher();
       const currentStep = ref(1);
       const totalSteps = 4;
       const isSubmittingCase = ref(false);
@@ -217,6 +219,14 @@
         if (route.query.src) formData.metadata.src = route.query.src;
         if (route.query.uniqueid) formData.metadata.src_uid = route.query.uniqueid;
         if (route.query.call_id) formData.metadata.src_callid = route.query.call_id;
+
+        // Catch-up fetch: if we landed here after a call ended and insights haven't
+        // been loaded yet (e.g. ATI notification arrived before navigation completed),
+        // try fetching now using the persisted call ID.
+        const catchUpId = route.query.uniqueid || activeCallStore.lastCallUniqueId
+        if (catchUpId && activeCallStore.aiInsights.length === 0) {
+          fetchAiInsightsForCall(catchUpId)
+        }
       });
 
       // ✅ Store BOTH reporter IDs separately

--- a/Helplinev2/finalui/src/components/case-create/CaseSingleFormView.vue
+++ b/Helplinev2/finalui/src/components/case-create/CaseSingleFormView.vue
@@ -338,6 +338,8 @@
   import { usePerpetratorStore } from '@/stores/perpetrators';
   import { useUserStore } from '@/stores/users';
   import { useTaxonomyStore } from '@/stores/taxonomy';
+  import { useActiveCallStore } from '@/stores/activeCall';
+  import { useAiInsightsFetcher } from '@/composables/useAiInsightsFetcher';
 
   const taxonomyStore = useTaxonomyStore();
   import { useAuthStore } from '@/stores/auth';
@@ -351,6 +353,8 @@
   const perpetratorStore = usePerpetratorStore();
   const userStore = useUserStore();
   const authStore = useAuthStore();
+  const activeCallStore = useActiveCallStore();
+  const { fetchAiInsightsForCall } = useAiInsightsFetcher();
 
   // State
   const isSearchingReporter = ref(false);
@@ -406,6 +410,13 @@
   onMounted(async () => {
     await reporterStore.listReporters();
     await userStore.listUsers();
+
+    // Catch-up fetch: if we landed here after a call ended and insights haven't
+    // been loaded yet, try fetching using the persisted call ID from the store.
+    const catchUpId = activeCallStore.lastCallUniqueId
+    if (catchUpId && activeCallStore.aiInsights.length === 0) {
+      fetchAiInsightsForCall(catchUpId)
+    }
   });
 
   // Reporter Logic

--- a/Helplinev2/finalui/src/composables/useAiInsightsFetcher.js
+++ b/Helplinev2/finalui/src/composables/useAiInsightsFetcher.js
@@ -1,0 +1,98 @@
+// composables/useAiInsightsFetcher.js
+// Shared logic for fetching post-call AI insights from the predictions pipeline.
+// Uses module-level singletons so dedup and in-progress state are shared across
+// all components that use this composable (DefaultLayout, CaseCreate, CaseSingleFormView).
+import { ref } from 'vue'
+import axiosInstance from '@/utils/axios'
+import { useActiveCallStore } from '@/stores/activeCall'
+import { useAuthStore } from '@/stores/auth'
+
+const _aiFetchInProgress = ref(false)
+const _fetchedCallIds = new Set()
+let _retryTimer = null
+
+export function useAiInsightsFetcher() {
+  const activeCallStore = useActiveCallStore()
+  const authStore = useAuthStore()
+
+  async function fetchAiInsightsForCall(queryCallId) {
+    if (!queryCallId || _aiFetchInProgress.value) return
+    if (_fetchedCallIds.has(queryCallId)) return
+
+    _aiFetchInProgress.value = true
+    _fetchedCallIds.add(queryCallId)
+
+    console.log('[AI Panel] Fetching insights for call_id:', queryCallId)
+
+    try {
+      // Step 1: Get conversation list to find the pmessage ID
+      const { data: listData } = await axiosInstance.get('api/pmessages/', {
+        params: { src_callid: queryCallId, src: 'aii', _c: 30 },
+        headers: { 'Session-Id': authStore.sessionId }
+      })
+
+      const conversations = listData.pmessages || []
+      const listKeys = listData.pmessages_k || {}
+
+      if (!conversations.length || !listKeys.id) {
+        console.log('[AI Panel] No conversations found for call_id:', queryCallId)
+        return
+      }
+
+      const idIdx = listKeys.id[0]
+
+      // Step 2: For each conversation fetch all individual messages
+      for (const conv of conversations) {
+        const pmessageId = conv[idIdx]
+        if (!pmessageId) continue
+
+        console.log('[AI Panel] Fetching message details for pmessage:', pmessageId)
+
+        const { data: detailData } = await axiosInstance.get(`api/pmessages/${pmessageId}?`, {
+          headers: { 'Session-Id': authStore.sessionId }
+        })
+
+        if (detailData.messages && detailData.messages_k) {
+          const msgKeys = detailData.messages_k
+          const srcMsgIdx = msgKeys.src_msg ? msgKeys.src_msg[0] : -1
+          if (srcMsgIdx === -1) continue
+
+          let added = 0
+          for (const row of detailData.messages) {
+            const rawMsg = row[srcMsgIdx]
+            if (!rawMsg) continue
+            try {
+              const decoded = JSON.parse(atob(rawMsg))
+              if (decoded && decoded.notification_type) {
+                activeCallStore.addAiInsight(decoded)
+                added++
+              }
+            } catch (e) {
+              // Skip non-JSON or invalid base64 entries
+            }
+          }
+          console.log(`[AI Panel] Decoded ${added} insights from pmessage ${pmessageId} (${detailData.messages.length} total messages)`)
+        }
+      }
+    } catch (err) {
+      console.warn('[AI Panel] Failed to fetch AI insights:', err.message)
+      // Remove from fetched set so a retry is possible
+      _fetchedCallIds.delete(queryCallId)
+    } finally {
+      _aiFetchInProgress.value = false
+    }
+  }
+
+  // Schedule a one-time retry to catch late-arriving insights (AI pipeline may still be writing)
+  function scheduleRetry(queryCallId, delayMs = 15000) {
+    if (_retryTimer) clearTimeout(_retryTimer)
+    _retryTimer = setTimeout(() => {
+      _retryTimer = null
+      console.log('[AI Panel] Retry fetch for late-arriving insights:', queryCallId)
+      _fetchedCallIds.delete(queryCallId)
+      fetchAiInsightsForCall(queryCallId)
+    }, delayMs)
+  }
+
+  return { fetchAiInsightsForCall, scheduleRetry }
+}

--- a/Helplinev2/finalui/src/layout/DefaultLayout.vue
+++ b/Helplinev2/finalui/src/layout/DefaultLayout.vue
@@ -26,13 +26,13 @@
 </template>
 
 <script setup>
-import { computed, provide, watch, ref, onMounted, onBeforeUnmount } from 'vue'
+import { computed, provide, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useRoute } from 'vue-router'
 import { useTheme } from '@/composables/useTheme'
 import { useAuthStore } from '@/stores/auth'
 import { useRealtimeStore } from '@/stores/realtime'
 import { useActiveCallStore } from '@/stores/activeCall'
-import axiosInstance from '@/utils/axios'
+import { useAiInsightsFetcher } from '@/composables/useAiInsightsFetcher'
 import Sidebar from '@/components/layout/Sidebar.vue'
 import Navbar from '@/components/layout/Navbar.vue'
 import ActiveCallToolbar from '@/components/softphone/ActiveCallToolbar.vue'
@@ -101,92 +101,10 @@ watch(
 
 // ── ATI → activeCall AI Insights Bridge ─────────────────────────
 // Monitors ATI text channel for AI notifications (src='aii', context='trunk')
-// and matches them against the active call via bridge_id or uniqueid, then
-// fetches the full insight payloads from the predictions API.
-//
-// Key: The AI service sends notifications with ATI_BRIDGE_ID = call UniqueID
-// (e.g. "1770654584.401"), NOT the Asterisk bridge UUID. Also, insights arrive
-// AFTER the call ends (20-120s processing), so we must keep matching even
-// during case-creation after wrapup.
-const _aiFetchInProgress = ref(false)
-const _lastCallUniqueId = ref('')
-const _fetchedCallIds = new Set() // Calls we've already fetched insights for
-let _retryTimer = null
-
-// Persist the call's UniqueID so it survives wrapup/idle transitions
-watch(() => activeCallStore.src_uid, (uid) => {
-  if (uid) {
-    console.log('[AI Panel] Tracking call UniqueID:', uid)
-    _lastCallUniqueId.value = uid
-  }
-})
-
-// Core function: fetch all individual AI messages for a call via two-step API
-async function fetchAiInsightsForCall(queryCallId) {
-  if (_aiFetchInProgress.value) return
-  _aiFetchInProgress.value = true
-
-  try {
-    console.log('[AI Panel] Fetching insights for call_id:', queryCallId)
-
-    // Step 1: Get conversation list to find the pmessage ID
-    const { data: listData } = await axiosInstance.get('api/pmessages/', {
-      params: { src_callid: queryCallId, src: 'aii', _c: 30 },
-      headers: { 'Session-Id': authStore.sessionId }
-    })
-
-    const conversations = listData.pmessages || []
-    const listKeys = listData.pmessages_k || {}
-
-    if (!conversations.length || !listKeys.id) {
-      console.log('[AI Panel] No conversations found for call_id:', queryCallId)
-      return
-    }
-
-    const idIdx = listKeys.id[0]
-
-    // Step 2: For each conversation, fetch ALL individual messages
-    for (const conv of conversations) {
-      const pmessageId = conv[idIdx]
-      if (!pmessageId) continue
-
-      console.log('[AI Panel] Fetching message details for pmessage:', pmessageId)
-
-      const { data: detailData } = await axiosInstance.get(`api/pmessages/${pmessageId}?`, {
-        headers: { 'Session-Id': authStore.sessionId }
-      })
-
-      // Step 3: Parse individual messages from the detail response
-      if (detailData.messages && detailData.messages_k) {
-        const msgKeys = detailData.messages_k
-        const srcMsgIdx = msgKeys.src_msg ? msgKeys.src_msg[0] : -1
-
-        if (srcMsgIdx === -1) continue
-
-        let added = 0
-        for (const row of detailData.messages) {
-          const rawMsg = row[srcMsgIdx]
-          if (!rawMsg) continue
-
-          try {
-            const decoded = JSON.parse(atob(rawMsg))
-            if (decoded && decoded.notification_type) {
-              activeCallStore.addAiInsight(decoded)
-              added++
-            }
-          } catch (e) {
-            // Skip non-JSON or invalid base64 entries
-          }
-        }
-        console.log(`[AI Panel] Decoded ${added} insights from pmessage ${pmessageId} (${detailData.messages.length} total messages)`)
-      }
-    }
-  } catch (err) {
-    console.warn('[AI Panel] Failed to fetch AI insights:', err.message)
-  } finally {
-    _aiFetchInProgress.value = false
-  }
-}
+// and matches them against the active call via bridge_id, src_uid, src_callid,
+// or lastCallUniqueId (persisted in store through wrapup into case-creation).
+// Insights arrive AFTER the call ends (20–120s processing).
+const { fetchAiInsightsForCall, scheduleRetry } = useAiInsightsFetcher()
 
 watch(
   () => realtimeStore.aiNotifications,
@@ -203,7 +121,8 @@ watch(
     const callIds = new Set()
     if (activeCallStore.bridge_id) callIds.add(activeCallStore.bridge_id)
     if (activeCallStore.src_uid) callIds.add(activeCallStore.src_uid)
-    if (_lastCallUniqueId.value) callIds.add(_lastCallUniqueId.value)
+    if (activeCallStore.src_callid) callIds.add(activeCallStore.src_callid)
+    if (activeCallStore.lastCallUniqueId) callIds.add(activeCallStore.lastCallUniqueId)
     if (route.query.uniqueid) callIds.add(route.query.uniqueid)
 
     if (callIds.size === 0) return
@@ -214,27 +133,10 @@ watch(
 
     const queryCallId = matchedNotif.ATI_BRIDGE_ID
 
-    // Already fetched for this call — skip
-    if (_fetchedCallIds.has(queryCallId)) return
-
-    // Prevent concurrent fetches
-    if (_aiFetchInProgress.value) return
-
     console.log('[AI Panel] ATI notification matched call_id:', queryCallId)
 
-    // Mark as fetched so we don't re-trigger on every ATI poll
-    _fetchedCallIds.add(queryCallId)
-
-    // Immediate fetch
     await fetchAiInsightsForCall(queryCallId)
-
-    // Schedule a retry after 15s to catch any late-arriving insights
-    // (AI pipeline may still be writing messages)
-    if (_retryTimer) clearTimeout(_retryTimer)
-    _retryTimer = setTimeout(() => {
-      console.log('[AI Panel] Retry fetch for late-arriving insights:', queryCallId)
-      fetchAiInsightsForCall(queryCallId)
-    }, 15000)
+    scheduleRetry(queryCallId)
   },
   { deep: true }
 )

--- a/Helplinev2/finalui/src/stores/activeCall.js
+++ b/Helplinev2/finalui/src/stores/activeCall.js
@@ -13,6 +13,7 @@ export const useActiveCallStore = defineStore('activeCall', () => {
     const bridge_id = ref('') // AMI CHAN_BRIDGE_ID — used for AI insight matching
     const aiInsights = ref([]) // Decoded AI insight payloads for current call
     const _seenInsightTypes = new Set() // Dedup tracker (notification_type keys)
+    const lastCallUniqueId = ref('') // Persists the call's CHAN_UNIQUEID across wrapup into case-creation
     const startedAt = ref(null)
     const durationSeconds = ref(0)
     const hasAudioTrack = ref(false)
@@ -89,6 +90,10 @@ export const useActiveCallStore = defineStore('activeCall', () => {
         }
 
         src_uid.value = null // Will be set later via AMI or header
+
+        // Seed lastCallUniqueId from SIP call-id immediately as a fallback.
+        // The AMI enrichment bridge will overwrite this with the accurate CHAN_UNIQUEID once available.
+        if (src_callid.value) lastCallUniqueId.value = src_callid.value
 
         // Queue confirmation call: Asterisk sends INVITE after agent joins queue.
         // Auto-answer this to complete the login, same as the old UI behavior.
@@ -266,6 +271,7 @@ export const useActiveCallStore = defineStore('activeCall', () => {
         src_callid.value = ''
         src_uid.value = null
         bridge_id.value = ''
+        lastCallUniqueId.value = ''
         startedAt.value = null
         durationSeconds.value = 0
         hasAudioTrack.value = false
@@ -287,6 +293,7 @@ export const useActiveCallStore = defineStore('activeCall', () => {
 
     function setAmiUniqueId(uid) {
         src_uid.value = uid
+        if (uid) lastCallUniqueId.value = uid // Overwrite fallback with accurate CHAN_UNIQUEID
     }
 
     function setBridgeId(id) {
@@ -521,6 +528,7 @@ export const useActiveCallStore = defineStore('activeCall', () => {
         src_uid,
         bridge_id,
         aiInsights,
+        lastCallUniqueId,
         startedAt,
         durationSeconds,
         hasAudioTrack,


### PR DESCRIPTION
## Summary

- Adds `lastCallUniqueId` to the `activeCall` store so the call ID survives wrapup into the case-creation page
- Extracts AI insights fetch logic into a shared `useAiInsightsFetcher` composable (module-level singletons prevent duplicate fetches)
- `DefaultLayout` now matches ATI notifications against `src_callid` and `lastCallUniqueId` in addition to `bridge_id` and `src_uid`
- `CaseCreate` and `CaseSingleFormView` both run a catch-up fetch on mount for insights that arrived before the agent navigated to case-creation

## Test plan

- [ ] End a call and navigate to case-creation — AI insights should appear in the right panel automatically
- [ ] Verify insights still load if the ATI notification arrived before navigating (catch-up fetch)
- [ ] Confirm no duplicate fetch requests are fired (check network tab)

Closes #528