### PR TITLE
fix: post-call AI insights panel and feedback endpoint

### DIFF
--- a/Helplinev2/finalui/src/components/predictions/AiFeedbackWidget.vue
+++ b/Helplinev2/finalui/src/components/predictions/AiFeedbackWidget.vue
@@ -37,7 +37,6 @@
 <script setup>
     import { ref, inject } from 'vue'
     import { toast } from 'vue-sonner'
-    import axiosInstance from '@/utils/axios'
 
     const props = defineProps({
         callId: {
@@ -70,7 +69,18 @@
         'postcall_insights': 'insights',
         'postcall_ai_service_insights': 'insights',
         'postcall_qa_scoring': 'qa',
-        'postcall_complete': 'insights'
+        'postcall_complete': 'insights',
+        'post_call_transcription': 'transcription',
+        'post_call_translation': 'translation',
+        'post_call_classification': 'classification',
+        'post_call_entities': 'ner',
+        'post_call_summary': 'summarization',
+        'post_call_summarization': 'summarization',
+        'post_call_mistral_insights': 'insights',
+        'post_call_insights': 'insights',
+        'post_call_ai_service_insights': 'insights',
+        'post_call_qa_scoring': 'qa',
+        'post_call_complete': 'insights'
     }
 
     const submitFeedback = async () => {
@@ -78,13 +88,20 @@
 
         submitting.value = true
         try {
-            await axiosInstance.post('api/feedback/', {
-                call_id: props.callId,
-                task: taskMap[props.taskType] || props.taskType,
-                feedback: rating.value,
-                reason: comment.value || null
+            const resp = await fetch('/audio-api/api/v1/agent-feedback/update', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    call_id: props.callId,
+                    task: taskMap[props.taskType] || props.taskType,
+                    feedback: rating.value,
+                    reason: comment.value || null
+                })
             })
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
             toast.success('Feedback submitted successfully')
+            rating.value = 0
+            comment.value = ''
         } catch (err) {
             console.error('Feedback error:', err)
             toast.error('Failed to submit feedback')

--- a/Helplinev2/finalui/src/composables/useAiInsightsFetcher.js
+++ b/Helplinev2/finalui/src/composables/useAiInsightsFetcher.js
@@ -2,18 +2,51 @@
 // Shared logic for fetching post-call AI insights from the predictions pipeline.
 // Uses module-level singletons so dedup and in-progress state are shared across
 // all components that use this composable (DefaultLayout, CaseCreate, CaseSingleFormView).
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import axiosInstance from '@/utils/axios'
 import { useActiveCallStore } from '@/stores/activeCall'
 import { useAuthStore } from '@/stores/auth'
 
 const _aiFetchInProgress = ref(false)
+const _isRetrying = ref(false)   // true while waiting between retries
+const _hasGivenUp = ref(false)   // true after all retries exhausted
+const _currentRetryAttempt = ref(0) // 0 = initial fetch, 1-4 = which retry we're on
 const _fetchedCallIds = new Set()
+const _retryCountMap = new Map() // callId → retry count (0-based)
+const RETRY_DELAYS = [15000, 30000, 60000, 120000]
 let _retryTimer = null
+let _bridgeIdResolved = false
+let _deferredFetchUnwatch = null
 
 export function useAiInsightsFetcher() {
   const activeCallStore = useActiveCallStore()
   const authStore = useAuthStore()
+
+  function _decodeAndStore(rawMsg) {
+    if (!rawMsg) return false
+    let decoded
+    try {
+      decoded = JSON.parse(rawMsg)
+    } catch {
+      try {
+        decoded = JSON.parse(atob(rawMsg))
+      } catch {
+        return false
+      }
+    }
+    if (!decoded) return false
+    // Support legacy `step` field when notification_type is absent
+    if (!decoded.notification_type && decoded.step) {
+      decoded.notification_type = 'post_call_' + decoded.step
+    }
+    if (decoded.notification_type) {
+      const normalized = decoded.notification_type.replace(/^postcall_/, 'post_call_')
+      if (!normalized.startsWith('post_call_')) return false
+      activeCallStore.addAiInsight(decoded)
+      return true
+    }
+    return false
+  }
 
   async function fetchAiInsightsForCall(queryCallId) {
     if (!queryCallId || _aiFetchInProgress.value) return
@@ -25,74 +58,152 @@ export function useAiInsightsFetcher() {
     console.log('[AI Panel] Fetching insights for call_id:', queryCallId)
 
     try {
-      // Step 1: Get conversation list to find the pmessage ID
-      const { data: listData } = await axiosInstance.get('api/pmessages/', {
-        params: { src_callid: queryCallId, src: 'aii', _c: 30 },
+      const { data } = await axiosInstance.get('api/messages/', {
+        params: { src_callid: queryCallId, _c: 30, sort: 'id' },
         headers: { 'Session-Id': authStore.sessionId }
       })
 
-      const conversations = listData.pmessages || []
-      const listKeys = listData.pmessages_k || {}
+      const messages = data.messages || []
+      const msgKeys = data.messages_k || {}
 
-      if (!conversations.length || !listKeys.id) {
-        console.log('[AI Panel] No conversations found for call_id:', queryCallId)
+      if (!messages.length) {
+        console.log('[AI Panel] No messages found for call_id:', queryCallId)
+        _fetchedCallIds.delete(queryCallId)
+        _scheduleRetry(queryCallId)
         return
       }
 
-      const idIdx = listKeys.id[0]
+      // src_msg is at index 17 (raw JSON, not base64)
+      const srcMsgIdx = msgKeys.src_msg ? msgKeys.src_msg[0] : 17
 
-      // Step 2: For each conversation fetch all individual messages
-      for (const conv of conversations) {
-        const pmessageId = conv[idIdx]
-        if (!pmessageId) continue
+      let added = 0
+      for (const row of messages) {
+        if (_decodeAndStore(row[srcMsgIdx])) added++
+      }
 
-        console.log('[AI Panel] Fetching message details for pmessage:', pmessageId)
+      console.log(`[AI Panel] Decoded ${added} insights from ${messages.length} messages for call ${queryCallId}`)
 
-        const { data: detailData } = await axiosInstance.get(`api/pmessages/${pmessageId}?`, {
-          headers: { 'Session-Id': authStore.sessionId }
-        })
-
-        if (detailData.messages && detailData.messages_k) {
-          const msgKeys = detailData.messages_k
-          const srcMsgIdx = msgKeys.src_msg ? msgKeys.src_msg[0] : -1
-          if (srcMsgIdx === -1) continue
-
-          let added = 0
-          for (const row of detailData.messages) {
-            const rawMsg = row[srcMsgIdx]
-            if (!rawMsg) continue
-            try {
-              const decoded = JSON.parse(atob(rawMsg))
-              if (decoded && decoded.notification_type) {
-                activeCallStore.addAiInsight(decoded)
-                added++
-              }
-            } catch (e) {
-              // Skip non-JSON or invalid base64 entries
-            }
-          }
-          console.log(`[AI Panel] Decoded ${added} insights from pmessage ${pmessageId} (${detailData.messages.length} total messages)`)
-        }
+      if (added === 0) {
+        // Messages exist but none decoded — retry in case pipeline is still writing
+        _fetchedCallIds.delete(queryCallId)
+        _scheduleRetry(queryCallId)
       }
     } catch (err) {
       console.warn('[AI Panel] Failed to fetch AI insights:', err.message)
-      // Remove from fetched set so a retry is possible
       _fetchedCallIds.delete(queryCallId)
+      _scheduleRetry(queryCallId)
     } finally {
       _aiFetchInProgress.value = false
     }
   }
 
-  // Schedule a one-time retry to catch late-arriving insights (AI pipeline may still be writing)
-  function scheduleRetry(queryCallId, delayMs = 15000) {
+  function _scheduleRetry(queryCallId) {
+    const count = _retryCountMap.get(queryCallId) ?? 0
+    if (count >= RETRY_DELAYS.length) {
+      console.log('[AI Panel] Max retries reached for call_id:', queryCallId)
+      _hasGivenUp.value = true
+      return
+    }
     if (_retryTimer) clearTimeout(_retryTimer)
+    const delay = RETRY_DELAYS[count]
+    _retryCountMap.set(queryCallId, count + 1)
+    _currentRetryAttempt.value = count + 1
+    _isRetrying.value = true
+    console.log(`[AI Panel] Scheduling retry ${count + 1}/${RETRY_DELAYS.length} in ${delay / 1000}s for:`, queryCallId)
     _retryTimer = setTimeout(() => {
       _retryTimer = null
-      console.log('[AI Panel] Retry fetch for late-arriving insights:', queryCallId)
-      _fetchedCallIds.delete(queryCallId)
+      _isRetrying.value = false
       fetchAiInsightsForCall(queryCallId)
-    }, delayMs)
+    }, delay)
   }
 
-  return { fetchAiInsightsForCall, scheduleRetry }
+  async function resolveAndFetch() {
+    // Block fetch while a call is in progress; re-run automatically on wrapup/idle
+    const state = activeCallStore.callState
+    if (['ringing', 'calling', 'active'].includes(state)) {
+      console.log('[AI Panel] Call in progress (' + state + ') — deferring fetch...')
+      if (_deferredFetchUnwatch) _deferredFetchUnwatch()
+      _deferredFetchUnwatch = watch(
+        () => activeCallStore.callState,
+        (newState) => {
+          if (['wrapup', 'idle'].includes(newState)) {
+            if (_deferredFetchUnwatch) { _deferredFetchUnwatch(); _deferredFetchUnwatch = null }
+            resolveAndFetch()
+          }
+        }
+      )
+      return
+    }
+
+    // Already have a valid Asterisk bridge_id (contains a dot: timestamp.sequence)
+    let callId = activeCallStore.bridge_id
+    if (callId && callId.includes('.')) {
+      if (activeCallStore.aiInsights.length === 0) fetchAiInsightsForCall(callId)
+      return
+    }
+
+    // Try to resolve from calls API using caller phone number (once per call)
+    if (!_bridgeIdResolved) {
+      _bridgeIdResolved = true
+      const callerNum = activeCallStore.callerNumber
+      const isValidCaller = callerNum && callerNum !== 'Unknown' && callerNum !== 'Unknown Caller'
+
+      if (isValidCaller) {
+        try {
+          const { data } = await axiosInstance.get('api/calls/', {
+            params: { phone: callerNum, _c: 1, _o: 0, _a: 0 },
+            headers: { 'Session-Id': authStore.sessionId }
+          })
+          const calls = data.calls || []
+          if (calls.length) {
+            const uidIdx = data.calls_k?.uniqueid?.[0] ?? 0
+            const resolved = calls[0][uidIdx]
+            if (resolved && String(resolved).includes('.')) {
+              console.log('[AI Panel] Resolved bridge_id from calls API:', resolved)
+              activeCallStore.setBridgeId(String(resolved))
+              callId = String(resolved)
+            }
+          }
+        } catch (e) {
+          console.warn('[AI Panel] Could not resolve bridge_id from calls API:', e.message)
+        }
+      }
+    }
+
+    // Fall back to lastCallUniqueId if resolution failed
+    if (!callId) callId = activeCallStore.lastCallUniqueId
+
+    if (callId && activeCallStore.aiInsights.length === 0) {
+      fetchAiInsightsForCall(callId)
+    }
+  }
+
+  function resetForNewCall() {
+    if (_retryTimer) {
+      clearTimeout(_retryTimer)
+      _retryTimer = null
+    }
+    if (_deferredFetchUnwatch) {
+      _deferredFetchUnwatch()
+      _deferredFetchUnwatch = null
+    }
+    _fetchedCallIds.clear()
+    _retryCountMap.clear()
+    _bridgeIdResolved = false
+    _isRetrying.value = false
+    _hasGivenUp.value = false
+    _currentRetryAttempt.value = 0
+    console.log('[AI Panel] Reset fetcher state for new call')
+  }
+
+  return {
+    fetchAiInsightsForCall,
+    resolveAndFetch,
+    resetForNewCall,
+    isFetching: _aiFetchInProgress,
+    isRetrying: _isRetrying,
+    hasGivenUp: _hasGivenUp,
+    retryAttempt: _currentRetryAttempt,
+    maxRetries: RETRY_DELAYS.length
+  }
 }

--- a/Helplinev2/finalui/src/config/taxonomyContract.js
+++ b/Helplinev2/finalui/src/config/taxonomyContract.js
@@ -31,6 +31,7 @@ export const ENVIRONMENT_REGISTRY = {
             DEV_TARGET_AMI: "https://192.168.10.3:8384",
             DEV_TARGET_ATI: "https://192.168.10.3:8384",
             DEV_TARGET_SIP: "https://192.168.10.3:8089",
+            DEV_TARGET_AI_SERVICE: "http://192.168.10.6:8125",
             SIP_WS_PATH: "/ws/",
             AMI_WS_PATH: "/ami/sync",
             ATI_WS_PATH: "/ati/sync"
@@ -101,6 +102,7 @@ export const ENVIRONMENT_REGISTRY = {
             DEV_TARGET_AMI: "https://192.168.8.13:8384",
             DEV_TARGET_ATI: "https://192.168.8.13:8384",
             DEV_TARGET_SIP: "https://192.168.8.13:8089",
+            DEV_TARGET_AI_SERVICE: "http://192.168.8.18:8125",
             SIP_WS_PATH: "/ws/",
             AMI_WS_PATH: "/ami/sync",
             ATI_WS_PATH: "/ati/sync"
@@ -171,6 +173,7 @@ export const ENVIRONMENT_REGISTRY = {
             DEV_TARGET_AMI: "https://192.168.10.119:8384",
             DEV_TARGET_ATI: "https://192.168.10.119:8384",
             DEV_TARGET_SIP: "https://192.168.10.119:8089",
+            DEV_TARGET_AI_SERVICE: "http://192.168.10.6:8125",
             SIP_WS_PATH: "/ws/",
             AMI_WS_PATH: "/ami/sync",
             ATI_WS_PATH: "/ati/sync"
@@ -241,6 +244,7 @@ export const ENVIRONMENT_REGISTRY = {
             DEV_TARGET_AMI: "https://demo-openchs.bitz-itc.com:8384",
             DEV_TARGET_ATI: "https://demo-openchs.bitz-itc.com:8384",
             DEV_TARGET_SIP: "https://demo-openchs.bitz-itc.com:8089",
+            DEV_TARGET_AI_SERVICE: "http://192.168.10.6:8125",
             SIP_WS_PATH: "/ws/",
             AMI_WS_PATH: "/ami/sync",
             ATI_WS_PATH: "/ati/sync"

--- a/Helplinev2/finalui/vite.config.js
+++ b/Helplinev2/finalui/vite.config.js
@@ -74,8 +74,11 @@ export default defineConfig(({ mode }) => {
             });
           },
         },
+        // NOTE FOR PRODUCTION (nginx): /audio-api/ must be proxied to the AI service
+        // (DEV_TARGET_AI_SERVICE) in your nginx config — required for both audio uploads
+        // and feedback submission (POST /audio-api/api/v1/agent-feedback/update).
         '/audio-api': {
-          target: 'http://192.168.8.18:8125',
+          target: endpoints.DEV_TARGET_AI_SERVICE || 'http://192.168.8.18:8125',
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/audio-api/, ''),
         },


### PR DESCRIPTION
## Summary

- **Fix premature/wrong insights fetch**: `resolveAndFetch()` now guards against active call states (`ringing`, `calling`, `active`) and defers via a reactive watcher that fires on `wrapup`/`idle`, ensuring the correct call's data is fetched — not the previous call's
- **Fix non-AI messages shown as insights**: `_decodeAndStore` now only accepts `post_call_*` / `postcall_*` notification types, dropping lifecycle events (`call_start`, `call_end_streaming`) that share the same messages table
- **Fix feedback 404**: Feedback submissions now POST to `/audio-api/api/v1/agent-feedback/update` (the AI service directly) instead of `api/feedback/` which does not exist on the main backend
- **Environment-aware AI service proxy**: Added `DEV_TARGET_AI_SERVICE` per environment in `taxonomyContract.js`; the `/audio-api` Vite proxy target now uses this instead of a hardcoded IP

## Test plan

- [ ] Open case-creation **during** an active call → panel shows wrapup card then spinner, **not** previous call's insights
- [ ] End call → wrapup → deferred watcher fires → correct call ID fetched → insights render
- [ ] Confirm no `[ActiveCall] AI Insight added: call_start` or `call_end_streaming` in console
- [ ] Submit star feedback on an insight card → no 404, success toast appears
- [ ] Verify nginx proxies `/audio-api/` to the AI service in production (required for both audio upload and feedback)