### PR TITLE
feat: AI insights panel displays post-call insights referencing agent's last call

### DIFF
--- a/Helplinev2/finalui/nginx.conf
+++ b/Helplinev2/finalui/nginx.conf
@@ -44,6 +44,15 @@ server {
         proxy_send_timeout 3600s;
     }
 
+    # AI Pipeline service (agent feedback, audio processing, etc.)
+    location /audio-api/ {
+        proxy_pass http://192.168.8.18:8125/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location /ati/ {
         proxy_pass https://192.168.8.13:8384/ati/;
         proxy_http_version 1.1;

--- a/Helplinev2/finalui/nginx.conf
+++ b/Helplinev2/finalui/nginx.conf
@@ -6,7 +6,7 @@ server {
 
     # API Proxy - Forward requests to backend
     location /api-proxy/ {
-        proxy_pass https://192.168.8.13/helpline/;
+        proxy_pass https://10.200.0.4/helpline/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -19,7 +19,7 @@ server {
     # proxy_read_timeout is critical for WebSockets — default 60s would kill
     # idle SIP/AMI connections, causing agents to drop from the queue.
     location /ws/ {
-        proxy_pass https://192.168.8.13/ws/;
+        proxy_pass https://10.200.0.4/ws/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -32,7 +32,7 @@ server {
     }
 
     location /ami/ {
-        proxy_pass https://192.168.8.13:8384/ami/;
+        proxy_pass https://10.200.0.4:8384/ami/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -46,7 +46,7 @@ server {
 
     # AI Pipeline service (agent feedback, audio processing, etc.)
     location /audio-api/ {
-        proxy_pass http://192.168.8.18:8125/;
+        proxy_pass http://10.200.0.4:8125/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -54,7 +54,7 @@ server {
     }
 
     location /ati/ {
-        proxy_pass https://192.168.8.13:8384/ati/;
+        proxy_pass https://10.200.0.4:8384/ati/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/Helplinev2/finalui/src/components/case-create/CaseCreate.vue
+++ b/Helplinev2/finalui/src/components/case-create/CaseCreate.vue
@@ -223,7 +223,7 @@
         // Catch-up fetch: if we landed here after a call ended and insights haven't
         // been loaded yet (e.g. ATI notification arrived before navigation completed),
         // try fetching now using the persisted call ID.
-        const catchUpId = route.query.uniqueid || activeCallStore.lastCallUniqueId
+        const catchUpId = route.query.call_id || route.query.uniqueid || activeCallStore.bridge_id || activeCallStore.lastCallUniqueId
         if (catchUpId && activeCallStore.aiInsights.length === 0) {
           fetchAiInsightsForCall(catchUpId)
         }

--- a/Helplinev2/finalui/src/components/case-create/CaseCreate.vue
+++ b/Helplinev2/finalui/src/components/case-create/CaseCreate.vue
@@ -224,7 +224,8 @@
         // been loaded yet (e.g. ATI notification arrived before navigation completed),
         // try fetching now using the persisted call ID.
         const catchUpId = route.query.call_id || route.query.uniqueid || activeCallStore.bridge_id || activeCallStore.lastCallUniqueId
-        if (catchUpId && activeCallStore.aiInsights.length === 0) {
+        const callIsLive = ['active', 'calling', 'ringing'].includes(activeCallStore.callState)
+        if (catchUpId && activeCallStore.aiInsights.length === 0 && !callIsLive) {
           fetchAiInsightsForCall(catchUpId)
         }
       });

--- a/Helplinev2/finalui/src/components/case-create/CaseSingleFormView.vue
+++ b/Helplinev2/finalui/src/components/case-create/CaseSingleFormView.vue
@@ -317,7 +317,7 @@
 
 <script setup>
   import { ref, reactive, inject, onMounted, computed, watch } from 'vue';
-  import { useRouter } from 'vue-router';
+  import { useRouter, useRoute } from 'vue-router';
   import { toast } from 'vue-sonner';
 
   import LegacyCaseLayout from './LegacyCaseLayout.vue';
@@ -345,6 +345,7 @@
   import { useAuthStore } from '@/stores/auth';
 
   const router = useRouter();
+  const route = useRoute();
   const isDarkMode = inject('isDarkMode');
 
   const casesStore = useCaseStore();
@@ -413,7 +414,7 @@
 
     // Catch-up fetch: if we landed here after a call ended and insights haven't
     // been loaded yet, try fetching using the persisted call ID from the store.
-    const catchUpId = activeCallStore.lastCallUniqueId
+    const catchUpId = route.query.call_id || route.query.uniqueid || activeCallStore.bridge_id || activeCallStore.lastCallUniqueId
     if (catchUpId && activeCallStore.aiInsights.length === 0) {
       fetchAiInsightsForCall(catchUpId)
     }

--- a/Helplinev2/finalui/src/components/layout/Navbar.vue
+++ b/Helplinev2/finalui/src/components/layout/Navbar.vue
@@ -29,10 +29,10 @@
           </span>
 
           <!-- Extension -->
-          <span v-if="authStore.user?.extension && queueStatus !== 'offline'"
+          <span v-if="sipStore.extension && queueStatus !== 'offline'"
             class="text-[10px] font-medium opacity-50 border-l pl-3"
             :class="isDarkMode ? 'border-white/10' : 'border-gray-200'">
-            Ext {{ authStore.user.extension }}
+            Ext {{ sipStore.extension }}
           </span>
 
           <!-- Caller Number (ringing/active/wrapup) -->
@@ -169,7 +169,7 @@
 
                 <div class="px-4 py-2 text-[11px] font-bold text-gray-500 opacity-80 flex items-center gap-2">
                   <i-mdi-phone-outline class="w-4 h-4" />
-                  Extension {{ authStore.user?.extension || '---' }}
+                  Extension {{ sipStore.extension || authStore.profile?.extension || authStore.profile?.exten || '---' }}
                 </div>
 
                 <!-- Auto Answer Toggle -->

--- a/Helplinev2/finalui/src/components/predictions/AiFeedbackWidget.vue
+++ b/Helplinev2/finalui/src/components/predictions/AiFeedbackWidget.vue
@@ -15,7 +15,13 @@
             <div v-else class="text-[10px] opacity-30 italic">Feedback unavailable</div>
         </div>
 
-        <div v-if="rating > 0" class="mt-3 space-y-3 animate-fadeIn">
+        <div v-if="submitted" class="mt-3 flex items-center gap-2 animate-fadeIn"
+            :class="isDarkMode ? 'text-green-400' : 'text-green-600'">
+            <i-mdi-check-circle class="w-4 h-4 flex-shrink-0" />
+            <span class="text-xs font-medium">Feedback submitted. Thank you!</span>
+        </div>
+
+        <div v-else-if="rating > 0" class="mt-3 space-y-3 animate-fadeIn">
             <textarea v-model="comment" rows="2" placeholder="Optional comments..."
                 class="w-full rounded-lg text-sm p-3 focus:outline-none focus:ring-2 transition-all resize-none" :class="isDarkMode
                     ? 'bg-neutral-900 border border-neutral-700 text-gray-200 focus:ring-indigo-500/50'
@@ -54,6 +60,7 @@
     const rating = ref(0)
     const comment = ref('')
     const submitting = ref(false)
+    const submitted = ref(false)
 
     const setRating = (val) => {
         rating.value = val
@@ -78,12 +85,18 @@
 
         submitting.value = true
         try {
-            await axiosInstance.post('api/feedback/', {
-                call_id: props.callId,
-                task: taskMap[props.taskType] || props.taskType,
-                feedback: rating.value,
-                reason: comment.value || null
+            const res = await fetch('/audio-api/api/v1/agent-feedback/update', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    call_id: props.callId,
+                    task: taskMap[props.taskType] || props.taskType,
+                    feedback: rating.value,
+                    reason: comment.value || null
+                })
             })
+            if (!res.ok) throw new Error(`HTTP ${res.status}`)
+            submitted.value = true
             toast.success('Feedback submitted successfully')
         } catch (err) {
             console.error('Feedback error:', err)

--- a/Helplinev2/finalui/src/composables/useAiInsightsFetcher.js
+++ b/Helplinev2/finalui/src/composables/useAiInsightsFetcher.js
@@ -25,55 +25,39 @@ export function useAiInsightsFetcher() {
     console.log('[AI Panel] Fetching insights for call_id:', queryCallId)
 
     try {
-      // Step 1: Get conversation list to find the pmessage ID
-      const { data: listData } = await axiosInstance.get('api/pmessages/', {
-        params: { src_callid: queryCallId, src: 'aii', _c: 30 },
+      // Fetch all AI messages for this call directly from the flat messages table.
+      // The ATI service stores insights via rest_uri_post("messages") — they live in
+      // the msg table (api/messages/), NOT in pmessage sessions (api/pmessages/).
+      const { data } = await axiosInstance.get('api/messages/', {
+        params: { src_callid: queryCallId, src: 'aii', _c: 30, sort: 'id' },
         headers: { 'Session-Id': authStore.sessionId }
       })
 
-      const conversations = listData.pmessages || []
-      const listKeys = listData.pmessages_k || {}
+      const messages = data.messages || []
+      const msgKeys = data.messages_k || {}
+      const srcMsgIdx = msgKeys.src_msg ? msgKeys.src_msg[0] : 17 // src_msg is at index 17
 
-      if (!conversations.length || !listKeys.id) {
-        console.log('[AI Panel] No conversations found for call_id:', queryCallId)
+      if (!messages.length) {
+        console.log('[AI Panel] No AI messages yet for call_id:', queryCallId)
+        _fetchedCallIds.delete(queryCallId)  // Allow retry when ATI notification arrives later
         return
       }
 
-      const idIdx = listKeys.id[0]
-
-      // Step 2: For each conversation fetch all individual messages
-      for (const conv of conversations) {
-        const pmessageId = conv[idIdx]
-        if (!pmessageId) continue
-
-        console.log('[AI Panel] Fetching message details for pmessage:', pmessageId)
-
-        const { data: detailData } = await axiosInstance.get(`api/pmessages/${pmessageId}?`, {
-          headers: { 'Session-Id': authStore.sessionId }
-        })
-
-        if (detailData.messages && detailData.messages_k) {
-          const msgKeys = detailData.messages_k
-          const srcMsgIdx = msgKeys.src_msg ? msgKeys.src_msg[0] : -1
-          if (srcMsgIdx === -1) continue
-
-          let added = 0
-          for (const row of detailData.messages) {
-            const rawMsg = row[srcMsgIdx]
-            if (!rawMsg) continue
-            try {
-              const decoded = JSON.parse(atob(rawMsg))
-              if (decoded && decoded.notification_type) {
-                activeCallStore.addAiInsight(decoded)
-                added++
-              }
-            } catch (e) {
-              // Skip non-JSON or invalid base64 entries
-            }
+      let added = 0
+      for (const row of messages) {
+        const rawMsg = row[srcMsgIdx]
+        if (!rawMsg) continue
+        try {
+          const decoded = JSON.parse(atob(rawMsg))
+          if (decoded && decoded.notification_type) {
+            activeCallStore.addAiInsight(decoded)
+            added++
           }
-          console.log(`[AI Panel] Decoded ${added} insights from pmessage ${pmessageId} (${detailData.messages.length} total messages)`)
+        } catch (e) {
+          // Skip non-JSON or invalid base64 entries
         }
       }
+      console.log(`[AI Panel] Decoded ${added} insights from ${messages.length} messages for call_id ${queryCallId}`)
     } catch (err) {
       console.warn('[AI Panel] Failed to fetch AI insights:', err.message)
       // Remove from fetched set so a retry is possible

--- a/Helplinev2/finalui/src/composables/useAiInsightsFetcher.js
+++ b/Helplinev2/finalui/src/composables/useAiInsightsFetcher.js
@@ -19,6 +19,10 @@ export function useAiInsightsFetcher() {
     if (!queryCallId || _aiFetchInProgress.value) return
     if (_fetchedCallIds.has(queryCallId)) return
 
+    // Never fetch insights while a call is live — they are post-call only
+    const callIsLive = ['active', 'calling', 'ringing'].includes(activeCallStore.callState)
+    if (callIsLive) return
+
     _aiFetchInProgress.value = true
     _fetchedCallIds.add(queryCallId)
 
@@ -83,11 +87,19 @@ export function useAiInsightsFetcher() {
     }
   }
 
-  // Schedule a one-time retry to catch late-arriving insights (AI pipeline may still be writing)
+  // Schedule a one-time retry to catch late-arriving insights (AI pipeline may still be writing).
+  // Snapshots the current bridge_id so the retry is silently dropped if the call context
+  // has changed by the time the timer fires (prevents stale call 1 data leaking into call 2).
   function scheduleRetry(queryCallId, delayMs = 15000) {
     if (_retryTimer) clearTimeout(_retryTimer)
+    const snapshotBridgeId = activeCallStore.bridge_id
     _retryTimer = setTimeout(() => {
       _retryTimer = null
+      // If the bridge ID changed since scheduling, this retry belongs to a stale call — skip it
+      if (activeCallStore.bridge_id !== snapshotBridgeId) {
+        console.log('[AI DEBUG] scheduleRetry cancelled — bridge_id changed from', snapshotBridgeId, 'to', activeCallStore.bridge_id)
+        return
+      }
       console.log('[AI DEBUG] scheduleRetry firing for call_id:', queryCallId, 'after', delayMs, 'ms')
       console.log('[AI Panel] Retry fetch for late-arriving insights:', queryCallId)
       _fetchedCallIds.delete(queryCallId)

--- a/Helplinev2/finalui/src/composables/useAiInsightsFetcher.js
+++ b/Helplinev2/finalui/src/composables/useAiInsightsFetcher.js
@@ -22,7 +22,11 @@ export function useAiInsightsFetcher() {
     _aiFetchInProgress.value = true
     _fetchedCallIds.add(queryCallId)
 
-    console.log('[AI Panel] Fetching insights for call_id:', queryCallId)
+    console.group(`[AI DEBUG] fetchAiInsightsForCall — call_id: ${queryCallId}`)
+    console.log('In progress:', _aiFetchInProgress.value)
+    console.log('Already fetched:', _fetchedCallIds.has(queryCallId))
+    console.log('Fetched IDs set:', [..._fetchedCallIds])
+    console.groupEnd()
 
     try {
       // Fetch all AI messages for this call directly from the flat messages table.
@@ -37,7 +41,18 @@ export function useAiInsightsFetcher() {
       const msgKeys = data.messages_k || {}
       const srcMsgIdx = msgKeys.src_msg ? msgKeys.src_msg[0] : 17 // src_msg is at index 17
 
+      console.group('[AI DEBUG] api/messages/ response')
+      console.log('params sent        :', { src_callid: queryCallId, src: 'aii', _c: 30, sort: 'id' })
+      console.log('messages count     :', messages.length)
+      console.log('messages_k         :', msgKeys)
+      console.log('srcMsgIdx used     :', srcMsgIdx)
+      if (messages.length > 0) {
+        console.log('first raw row      :', messages[0])
+      }
+      console.groupEnd()
+
       if (!messages.length) {
+        console.warn('[AI DEBUG] api/messages/ returned 0 results for call_id:', queryCallId, '— will allow retry')
         console.log('[AI Panel] No AI messages yet for call_id:', queryCallId)
         _fetchedCallIds.delete(queryCallId)  // Allow retry when ATI notification arrives later
         return
@@ -49,6 +64,7 @@ export function useAiInsightsFetcher() {
         if (!rawMsg) continue
         try {
           const decoded = JSON.parse(atob(rawMsg))
+          console.log('[AI DEBUG] decoded insight:', decoded?.notification_type, decoded)
           if (decoded && decoded.notification_type) {
             activeCallStore.addAiInsight(decoded)
             added++
@@ -72,6 +88,7 @@ export function useAiInsightsFetcher() {
     if (_retryTimer) clearTimeout(_retryTimer)
     _retryTimer = setTimeout(() => {
       _retryTimer = null
+      console.log('[AI DEBUG] scheduleRetry firing for call_id:', queryCallId, 'after', delayMs, 'ms')
       console.log('[AI Panel] Retry fetch for late-arriving insights:', queryCallId)
       _fetchedCallIds.delete(queryCallId)
       fetchAiInsightsForCall(queryCallId)

--- a/Helplinev2/finalui/src/config/taxonomyContract.js
+++ b/Helplinev2/finalui/src/config/taxonomyContract.js
@@ -20,27 +20,27 @@ export const ENVIRONMENT_REGISTRY = {
         COUNTRY_CODE: "255",
         ENDPOINTS: {
             API_BASE: "/api-proxy",
-            BACKEND_URL: "https://192.168.10.3",
+            BACKEND_URL: "https://10.200.0.3",
             BACKEND_PATH: "/hh19jan2026",
-            GATEWAY_AUTH: "https://192.168.10.3/v1/token/",
-            GATEWAY_SEND_MSG: "https://192.168.10.3/v1/chat/",
-            AMI_HOST: "wss://192.168.10.3:8384/ami/sync",
-            ATI_HOST: "wss://192.168.10.3:8384/ati/sync",
+            GATEWAY_AUTH: "https://10.200.0.3/v1/token/",
+            GATEWAY_SEND_MSG: "https://10.200.0.3/v1/chat/",
+            AMI_HOST: "wss://10.200.0.3:8384/ami/sync",
+            ATI_HOST: "wss://10.200.0.3:8384/ati/sync",
             // Dev Proxy Targets (used by vite.config.js and smart proxy logic)
-            DEV_TARGET_API: "https://192.168.10.3",
-            DEV_TARGET_AMI: "https://192.168.10.3:8384",
-            DEV_TARGET_ATI: "https://192.168.10.3:8384",
-            DEV_TARGET_SIP: "https://192.168.10.3:8089",
+            DEV_TARGET_API: "https://10.200.0.3",
+            DEV_TARGET_AMI: "https://10.200.0.3:8384",
+            DEV_TARGET_ATI: "https://10.200.0.3:8384",
+            DEV_TARGET_SIP: "https://10.200.0.3:8089",
             SIP_WS_PATH: "/ws/",
             AMI_WS_PATH: "/ami/sync",
             ATI_WS_PATH: "/ati/sync"
         },
         VOIP: {
-            SIP_HOST: "192.168.10.3",
-            SIP_WS_URL: "wss://192.168.10.3:8089/ws",
+            SIP_HOST: "10.200.0.3",
+            SIP_WS_URL: "wss://10.200.0.3:8089/ws",
             SIP_USER_PREFIX: "0",
             SIP_PASS_PREFIX: "0",
-            ICE_SERVERS: parseIceServers(import.meta.env?.VITE_TZ_STUN_SERVERS || 'stun:stun.l.google.com:19302,stun:192.168.10.3:3479')
+            ICE_SERVERS: parseIceServers(import.meta.env?.VITE_TZ_STUN_SERVERS || 'stun:stun.l.google.com:19302,stun:10.200.0.3:3479')
         },
         ROOTS: {
             CASE_CATEGORY: "362559",
@@ -84,30 +84,30 @@ export const ENVIRONMENT_REGISTRY = {
         }
     },
 
-    // --- KENYA LOCAL / LAN CONFIG (192.168.8.13) ---
+    // --- KENYA LOCAL / LAN CONFIG (10.200.0.3) ---
     'KE_LOCAL': {
         COUNTRY_NAME: "Kenya Local",
         COUNTRY_CODE: "254",
         ENDPOINTS: {
             API_BASE: "/api-proxy",
-            BACKEND_URL: "https://192.168.8.13",
+            BACKEND_URL: "https://10.200.0.3",
             BACKEND_PATH: "/helpline",
             GATEWAY_AUTH: "https://demo-openchs.bitz-itc.com/api/token/",
             GATEWAY_SEND_MSG: "https://backend.bitz-itc.com/api/whatsapp/whatsapp/send/",
-            AMI_HOST: "wss://192.168.8.13:8384/ami/sync",
-            ATI_HOST: "wss://192.168.8.13:8384/ati/sync",
+            AMI_HOST: "wss://10.200.0.3:8384/ami/sync",
+            ATI_HOST: "wss://10.200.0.3:8384/ati/sync",
             // Dev Proxy Targets
-            DEV_TARGET_API: "https://192.168.8.13",
-            DEV_TARGET_AMI: "https://192.168.8.13:8384",
-            DEV_TARGET_ATI: "https://192.168.8.13:8384",
-            DEV_TARGET_SIP: "https://192.168.8.13:8089",
+            DEV_TARGET_API: "https://10.200.0.3",
+            DEV_TARGET_AMI: "https://10.200.0.3:8384",
+            DEV_TARGET_ATI: "https://10.200.0.3:8384",
+            DEV_TARGET_SIP: "https://10.200.0.3:8089",
             SIP_WS_PATH: "/ws/",
             AMI_WS_PATH: "/ami/sync",
             ATI_WS_PATH: "/ati/sync"
         },
         VOIP: {
-            SIP_HOST: "192.168.8.13",
-            SIP_WS_URL: "wss://192.168.8.13/ws/",
+            SIP_HOST: "10.200.0.3",
+            SIP_WS_URL: "wss://10.200.0.3/ws/",
             SIP_USER_PREFIX: "",
             SIP_PASS_PREFIX: import.meta.env?.VITE_SIP_PASS_PREFIX || '',
             ICE_SERVERS: parseIceServers()
@@ -154,30 +154,30 @@ export const ENVIRONMENT_REGISTRY = {
         }
     },
 
-    // --- KENYA VPN CONFIG (192.168.10.119 → same backend as KE_LOCAL) ---
+    // --- KENYA VPN CONFIG (10.200.0.3 → same backend as KE_LOCAL) ---
     'KE_VPN': {
         COUNTRY_NAME: "Kenya VPN",
         COUNTRY_CODE: "254",
         ENDPOINTS: {
             API_BASE: "/api-proxy",
-            BACKEND_URL: "https://192.168.10.119",
+            BACKEND_URL: "https://10.200.0.3",
             BACKEND_PATH: "/helpline",
             GATEWAY_AUTH: "https://demo-openchs.bitz-itc.com/api/token/",
             GATEWAY_SEND_MSG: "https://backend.bitz-itc.com/api/whatsapp/whatsapp/send/",
-            AMI_HOST: "wss://192.168.10.119:8384/ami/sync",
-            ATI_HOST: "wss://192.168.10.119:8384/ati/sync",
+            AMI_HOST: "wss://10.200.0.3:8384/ami/sync",
+            ATI_HOST: "wss://10.200.0.3:8384/ati/sync",
             // Dev Proxy Targets
-            DEV_TARGET_API: "https://192.168.10.119",
-            DEV_TARGET_AMI: "https://192.168.10.119:8384",
-            DEV_TARGET_ATI: "https://192.168.10.119:8384",
-            DEV_TARGET_SIP: "https://192.168.10.119:8089",
+            DEV_TARGET_API: "https://10.200.0.3",
+            DEV_TARGET_AMI: "https://10.200.0.3:8384",
+            DEV_TARGET_ATI: "https://10.200.0.3:8384",
+            DEV_TARGET_SIP: "https://10.200.0.3:8089",
             SIP_WS_PATH: "/ws/",
             AMI_WS_PATH: "/ami/sync",
             ATI_WS_PATH: "/ati/sync"
         },
         VOIP: {
-            SIP_HOST: "192.168.10.119",
-            SIP_WS_URL: "wss://192.168.10.119/ws/",
+            SIP_HOST: "10.200.0.3",
+            SIP_WS_URL: "wss://10.200.0.3/ws/",
             SIP_USER_PREFIX: "",
             SIP_PASS_PREFIX: import.meta.env?.VITE_SIP_PASS_PREFIX || '',
             ICE_SERVERS: parseIceServers()

--- a/Helplinev2/finalui/src/layout/DefaultLayout.vue
+++ b/Helplinev2/finalui/src/layout/DefaultLayout.vue
@@ -124,12 +124,22 @@ watch(
     if (activeCallStore.src_callid) callIds.add(activeCallStore.src_callid)
     if (activeCallStore.lastCallUniqueId) callIds.add(activeCallStore.lastCallUniqueId)
     if (route.query.uniqueid) callIds.add(route.query.uniqueid)
+    if (route.query.call_id) callIds.add(route.query.call_id)
 
     if (callIds.size === 0) return
 
     // Find matching notification
-    const matchedNotif = notifications.find(n => callIds.has(n.ATI_BRIDGE_ID))
-    if (!matchedNotif) return
+    let matchedNotif = notifications.find(n => callIds.has(n.ATI_BRIDGE_ID))
+
+    if (!matchedNotif) {
+      // Fallback: on case-creation page, accept the first AI notification even without
+      // an ID match. bridge_id may be missing if AMI didn't connect during the call.
+      if (!isCaseCreation) return
+      matchedNotif = notifications[0]
+      if (!matchedNotif) return
+      console.log('[AI Panel] No ID match — using fallback ATI_BRIDGE_ID:', matchedNotif.ATI_BRIDGE_ID)
+      activeCallStore.setBridgeId(matchedNotif.ATI_BRIDGE_ID) // Sync for dedup + retry consistency
+    }
 
     const queryCallId = matchedNotif.ATI_BRIDGE_ID
 

--- a/Helplinev2/finalui/src/layout/DefaultLayout.vue
+++ b/Helplinev2/finalui/src/layout/DefaultLayout.vue
@@ -82,18 +82,33 @@ watch(
     const ext = authStore.profile?.extension || authStore.profile?.exten
     if (!ext) return
 
-    const match = channels.find(ch =>
-      ch.CHAN_EXTEN === String(ext) ||
-      ch.CHAN_CALLERID_NUM === activeCallStore.callerNumber
+    const matches = channels.filter(ch =>
+      (ch.CHAN_EXTEN === String(ext) ||
+       ch.CHAN_CALLERID_NUM === activeCallStore.callerNumber) &&
+      (ch.CHAN_STATE_UP || ch.CHAN_STATE_QUEUE || ch.CHAN_STATE_CONNECT)
     )
+    // Sort descending by CHAN_UNIQUEID (epoch.sequence) so the most recently
+    // created channel wins — stale channels from prior calls sort to the back.
+    const match = matches.sort((a, b) =>
+      parseFloat(b.CHAN_UNIQUEID) - parseFloat(a.CHAN_UNIQUEID)
+    )[0]
 
     if (match) {
+      console.group('[AMI] Call ID snapshot — state: ' + activeCallStore.callState)
+      console.log('candidates          :', matches.length, '→ UIDs:', matches.map(c => c.CHAN_UNIQUEID))
+      console.log('selected CHAN_UNIQUEID  :', match.CHAN_UNIQUEID)
+      console.log('selected CHAN_UNIQUEID_2:', match.CHAN_UNIQUEID_2, '← = ATI_BRIDGE_ID (stored as lastCallerUniqueId)')
+      console.log('selected CHAN_BRIDGE_ID :', match.CHAN_BRIDGE_ID)
+      console.groupEnd()
+
       if (!activeCallStore.src_uid && match.CHAN_UNIQUEID) {
-        console.log('[Realtime] AMI enrichment: syncing UniqueID', match.CHAN_UNIQUEID)
         activeCallStore.setAmiUniqueId(match.CHAN_UNIQUEID)
       }
       if (match.CHAN_BRIDGE_ID) {
         activeCallStore.setBridgeId(match.CHAN_BRIDGE_ID)
+      }
+      if (match.CHAN_UNIQUEID_2) {
+        activeCallStore.setCallerUniqueId(match.CHAN_UNIQUEID_2)
       }
     }
   }
@@ -111,11 +126,14 @@ watch(
   async (notifications) => {
     if (!notifications.length) return
 
-    // Allow processing during active call, wrapup, OR while on case-creation page
-    const isActiveCall = ['active', 'wrapup'].includes(activeCallStore.callState)
-    const isCaseCreation = route.path.includes('case-creation')
+    // AI insights are post-call; block entirely during live call states
+    const callIsLive = ['active', 'calling', 'ringing'].includes(activeCallStore.callState)
+    if (callIsLive) return
 
-    if (!isActiveCall && !isCaseCreation) return
+    const isCaseCreation = route.path.includes('case-creation')
+    const isWrapup = activeCallStore.callState === 'wrapup'
+
+    if (!isWrapup && !isCaseCreation) return
 
     // Collect all possible IDs to match against ATI_BRIDGE_ID
     const callIds = new Set()
@@ -123,6 +141,7 @@ watch(
     if (activeCallStore.src_uid) callIds.add(activeCallStore.src_uid)
     if (activeCallStore.src_callid) callIds.add(activeCallStore.src_callid)
     if (activeCallStore.lastCallUniqueId) callIds.add(activeCallStore.lastCallUniqueId)
+    if (activeCallStore.lastCallerUniqueId) callIds.add(activeCallStore.lastCallerUniqueId)
     if (route.query.uniqueid) callIds.add(route.query.uniqueid)
     if (route.query.call_id) callIds.add(route.query.call_id)
 
@@ -132,18 +151,33 @@ watch(
     let matchedNotif = notifications.find(n => callIds.has(n.ATI_BRIDGE_ID))
 
     if (!matchedNotif) {
-      // Fallback: on case-creation page, accept the first AI notification even without
-      // an ID match. bridge_id may be missing if AMI didn't connect during the call.
-      if (!isCaseCreation) return
-      matchedNotif = notifications[0]
+      // Only use fallback when: on case-creation page AND no insights loaded yet.
+      // If insights already loaded (e.g. from catch-up fetch), don't pick a different
+      // call's notification — that would add a second call's insights on top.
+      if (!isCaseCreation || activeCallStore.aiInsights.length > 0) return
+      matchedNotif = notifications.reduce((latest, n) => {
+        return parseFloat(n.ATI_BRIDGE_ID) > parseFloat(latest.ATI_BRIDGE_ID) ? n : latest
+      }, notifications[0])
       if (!matchedNotif) return
       console.log('[AI Panel] No ID match — using fallback ATI_BRIDGE_ID:', matchedNotif.ATI_BRIDGE_ID)
-      activeCallStore.setBridgeId(matchedNotif.ATI_BRIDGE_ID) // Sync for dedup + retry consistency
+      activeCallStore.setBridgeId(matchedNotif.ATI_BRIDGE_ID)
     }
 
     const queryCallId = matchedNotif.ATI_BRIDGE_ID
 
+    console.group('[AI DEBUG] ATI notification — call ID resolution')
+    console.log('ATI_BRIDGE_ID (from notification)  :', queryCallId)
+    console.log('activeCallStore.bridge_id           :', activeCallStore.bridge_id)
+    console.log('activeCallStore.lastCallUniqueId     :', activeCallStore.lastCallUniqueId)
+    console.log('activeCallStore.src_uid              :', activeCallStore.src_uid)
+    console.log('activeCallStore.src_callid           :', activeCallStore.src_callid)
+    console.log('activeCallStore.callState            :', activeCallStore.callState)
+    console.log('route.query.call_id                  :', route.query.call_id)
+    console.log('route.query.uniqueid                 :', route.query.uniqueid)
+    console.groupEnd()
+
     console.log('[AI Panel] ATI notification matched call_id:', queryCallId)
+    console.log('Call Ids in store:', Array.from(callIds).join(', '))
 
     await fetchAiInsightsForCall(queryCallId)
     scheduleRetry(queryCallId)

--- a/Helplinev2/finalui/src/stores/activeCall.js
+++ b/Helplinev2/finalui/src/stores/activeCall.js
@@ -11,6 +11,7 @@ export const useActiveCallStore = defineStore('activeCall', () => {
     const src_callid = ref('')
     const src_uid = ref(null) // AMI CHAN_UNIQUEID
     const bridge_id = ref('') // AMI CHAN_BRIDGE_ID — used for AI insight matching
+    const lastCallerUniqueId = ref('') // CHAN_UNIQUEID_2 — the caller's Asterisk uniqueid, equals ATI_BRIDGE_ID
     const aiInsights = ref([]) // Decoded AI insight payloads for current call
     const _seenInsightTypes = new Set() // Dedup tracker (notification_type keys)
     const lastCallUniqueId = ref('') // Persists the call's CHAN_UNIQUEID across wrapup into case-creation
@@ -61,6 +62,12 @@ export const useActiveCallStore = defineStore('activeCall', () => {
         if (callState.value !== 'idle') {
             console.warn('[STORE-DEBUG] Incoming call while busy - overriding session', callState.value)
             resetCall() // Force clear previous outbound state
+        } else {
+            // New call on idle — clear previous call's AI state for fresh start
+            clearAiInsights()
+            bridge_id.value = ''
+            lastCallUniqueId.value = ''
+            lastCallerUniqueId.value = ''
         }
 
         currentSession.value = session
@@ -273,6 +280,7 @@ export const useActiveCallStore = defineStore('activeCall', () => {
         src_uid.value = null
         bridge_id.value = ''
         lastCallUniqueId.value = ''
+        lastCallerUniqueId.value = ''
         startedAt.value = null
         durationSeconds.value = 0
         hasAudioTrack.value = false
@@ -302,6 +310,10 @@ export const useActiveCallStore = defineStore('activeCall', () => {
             console.log('[ActiveCall] Bridge ID set:', id)
             bridge_id.value = id
         }
+    }
+
+    function setCallerUniqueId(uid) {
+        if (uid) lastCallerUniqueId.value = uid
     }
 
     function addAiInsight(payload) {
@@ -528,6 +540,7 @@ export const useActiveCallStore = defineStore('activeCall', () => {
         src_callid,
         src_uid,
         bridge_id,
+        lastCallerUniqueId,
         aiInsights,
         lastCallUniqueId,
         startedAt,
@@ -549,6 +562,7 @@ export const useActiveCallStore = defineStore('activeCall', () => {
         endWrapup,
         setAmiUniqueId,
         setBridgeId,
+        setCallerUniqueId,
         addAiInsight,
         clearAiInsights,
         autoAnswerEnabled,

--- a/Helplinev2/finalui/src/stores/activeCall.js
+++ b/Helplinev2/finalui/src/stores/activeCall.js
@@ -253,7 +253,8 @@ export const useActiveCallStore = defineStore('activeCall', () => {
         ssid.value = ''
         src_callid.value = ''
         src_uid.value = null
-        bridge_id.value = ''
+        // bridge_id is intentionally kept here — cleared by resetCall() on the next call.
+        // This ensures catch-up fetches on case-creation can still match src_callid after wrapup expires.
         startedAt.value = null
         durationSeconds.value = 0
         // Don't clear aiInsights here — insights arrive AFTER call ends (20-120s processing)

--- a/Helplinev2/finalui/src/stores/realtime.js
+++ b/Helplinev2/finalui/src/stores/realtime.js
@@ -237,6 +237,11 @@ export const useRealtimeStore = defineStore('realtime', {
       }
 
       this.atiInteractions = parsed
+
+      const aiCount = Object.values(parsed).filter(i => i.ATI_SRC === 'aii').length
+      if (aiCount > 0) {
+        console.log(`[Realtime] ATI poll: ${aiCount} AI notification(s) present`)
+      }
     },
 
     // ── Host Resolution ────────────────────────────────────────────

--- a/Helplinev2/finalui/src/stores/realtime.js
+++ b/Helplinev2/finalui/src/stores/realtime.js
@@ -268,9 +268,10 @@ export const useRealtimeStore = defineStore('realtime', {
       if (this._amiWs && this.amiReady === 'open') return
 
       const taxonomyStore = useTaxonomyStore()
-      // Use proxy path so requests go through Vite (dev) or nginx (prod)
+      const amiEnvUrl = import.meta.env.VITE_AMI_WS_URL
       const amiPath = taxonomyStore.endpoints?.AMI_WS_PATH || '/ami/sync'
-      const resolved = this.resolveWsHost(amiPath)
+      const base = amiEnvUrl || amiPath
+      const resolved = this.resolveWsHost(base)
       const url = `${resolved}${resolved.includes('?') ? '&' : '?'}c=-2`
 
       console.log('[Realtime] Connecting AMI:', url)
@@ -289,14 +290,15 @@ export const useRealtimeStore = defineStore('realtime', {
           try { this.handleAmiMessage(ev.data) } catch {}
         }
 
-        ws.onclose = () => {
-          console.log('[Realtime] AMI disconnected')
+        ws.onclose = (ev) => {
+          console.log(`[Realtime] AMI disconnected — code=${ev.code} reason="${ev.reason}" wasClean=${ev.wasClean}`)
           this.amiReady = 'closed'
           this._amiWs = null
           this.scheduleReconnect('ami')
         }
 
-        ws.onerror = () => {
+        ws.onerror = (ev) => {
+          console.warn('[Realtime] AMI error', ev)
           this.amiReady = 'error'
         }
 


### PR DESCRIPTION
## Summary
- Wire AI insights panel to display post-call insights tied to the agent's last call ID
- Fix AI feedback submission payload alignment with AI service API schema
- Fix extension number display in Navbar — now reads from `sipStore.extension` instead of undefined `authStore.user`
- Prevent stale insights from a previous call leaking into the next call's case-creation context

## Key Changes
- `useAiInsightsFetcher.js` — add `callIsLive` guard and bridge-ID snapshot in retry to block stale fetches across call boundaries
- `Navbar.vue` — read extension from `sipStore.extension` with fallback chain to `authStore.profile`
- `AiFeedbackWidget.vue` — fix feedback submission and mark submitted state correctly
- Environment/IP config updates across TZ, KE_LOCAL and KE_VPN environments

## Test Plan
- [ ] Log in as a counsellor with SIP enabled — extension should display in navbar and dropdown
- [ ] Complete a call — post-call AI insights should appear in the case-creation panel referencing that call's ID
- [ ] Take a second call immediately after the first — only the second call's insights should appear (no bleed from call 1)
- [ ] Submit AI feedback on an insight card — should succeed without errors