### PR TITLE
fix: prevent stale ATI notifications from loading previous call's insights

### DIFF
--- a/Helplinev2/finalui/src/layout/DefaultLayout.vue
+++ b/Helplinev2/finalui/src/layout/DefaultLayout.vue
@@ -151,16 +151,13 @@ watch(
     let matchedNotif = notifications.find(n => callIds.has(n.ATI_BRIDGE_ID))
 
     if (!matchedNotif) {
-      // Only use fallback when: on case-creation page AND no insights loaded yet.
-      // If insights already loaded (e.g. from catch-up fetch), don't pick a different
-      // call's notification — that would add a second call's insights on top.
-      if (!isCaseCreation || activeCallStore.aiInsights.length > 0) return
-      matchedNotif = notifications.reduce((latest, n) => {
-        return parseFloat(n.ATI_BRIDGE_ID) > parseFloat(latest.ATI_BRIDGE_ID) ? n : latest
-      }, notifications[0])
-      if (!matchedNotif) return
-      console.log('[AI Panel] No ID match — using fallback ATI_BRIDGE_ID:', matchedNotif.ATI_BRIDGE_ID)
-      activeCallStore.setBridgeId(matchedNotif.ATI_BRIDGE_ID)
+      // No ATI notification matches any of our known call IDs — the real notification
+      // for this call hasn't arrived yet (AI pipeline takes 20–120s post-call).
+      // Do NOT fall back to the numerically largest ATI_BRIDGE_ID; that would pick up
+      // a stale notification from a previous call and load the wrong insights.
+      // Just wait — the watcher will fire again when the correct notification arrives.
+      console.log('[AI Panel] No ID match for current call IDs:', Array.from(callIds), '— waiting for correct ATI notification')
+      return
     }
 
     const queryCallId = matchedNotif.ATI_BRIDGE_ID


### PR DESCRIPTION
## Summary
- Removes the fallback in `DefaultLayout.vue` that picked the numerically largest `ATI_BRIDGE_ID` when no ATI notification matched the current call's known IDs
- This fallback was causing AI insights from a **previous call** to appear immediately (within seconds) instead of waiting 20–120s for the current call's AI pipeline to complete
- The fix relies on the watcher's reactive nature — it fires again automatically when the correct ATI notification arrives, at which point the ID match succeeds cleanly

## Root Cause
After a call ends, the ATI poll may still hold a notification from a previous call (e.g. `1784806174.21`). If the current call's notification hasn't arrived yet, the fallback logic would pick the stale one and trigger a fetch with the wrong call ID, loading the wrong insights panel data.

## Test plan
- [ ] Complete a call and wait on the case-creation page
- [ ] Verify AI insights do **not** appear immediately with an old call ID
- [ ] Verify insights appear correctly after ~20–120s once the AI pipeline finishes for the current call
- [ ] Confirm console shows `[AI Panel] No ID match for current call IDs: [...] — waiting for correct ATI notification` until the real notification arrives